### PR TITLE
Add a Text Input plugin

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -191,6 +191,15 @@
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value="org.kde.kdeconnect.UserInterface.MainActivity" />
         </activity>
+
+        <activity android:name="org.kde.kdeconnect.Plugins.TextInputPlugin.TextInputActivity"
+            android:label="@string/pref_plugin_textinput"
+            android:parentActivityName="org.kde.kdeconnect.UserInterface.MainActivity">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="org.kde.kdeconnect.UserInterface.MainActivity" />
+        </activity>
+
         <activity
             android:name="org.kde.kdeconnect.Plugins.PresenterPlugin.PresenterActivity"
             android:configChanges="orientation|keyboardHidden|screenSize"

--- a/res/layout/activity_textinput.xml
+++ b/res/layout/activity_textinput.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/textinput_view"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:keepScreenOn="true"
+    android:orientation="vertical">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+
+        <EditText
+            android:id="@+id/textInputField"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:ems="10"
+            android:gravity="top"
+            android:hint="@string/textinput_info"
+            android:selectAllOnFocus="false"
+            android:singleLine="false" />
+    </LinearLayout>
+</RelativeLayout>

--- a/res/menu/menu_textinput.xml
+++ b/res/menu/menu_textinput.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:kdeconnect="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/menu_submit_text"
+        android:icon="@drawable/ic_play_white"
+        android:title="@string/submit"
+        kdeconnect:showAsAction="always" />
+
+</menu>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -12,6 +12,8 @@
     <string name="pref_plugin_sftp_desc">Allows to browse this device\'s filesystem remotely</string>
     <string name="pref_plugin_clipboard">Clipboard sync</string>
     <string name="pref_plugin_clipboard_desc">Share the clipboard content</string>
+    <string name="pref_plugin_textinput">Text pad</string>
+    <string name="pref_plugin_textinput_desc">Input text on the PC using your mobile keyboard (e.g. for handwriting)</string>
     <string name="pref_plugin_mousepad">Remote input</string>
     <string name="pref_plugin_mousepad_desc">Use your phone or tablet as a touchpad and keyboard</string>
     <string name="pref_plugin_presenter">Presentation remote</string>
@@ -47,6 +49,7 @@
     <string name="remotekeyboard_connected" translatable="true">Remote keyboard connection is active</string>
     <string name="remotekeyboard_multiple_connections" translatable="true">There is more than one remote keyboard connection, select the device to configure</string>
     <string name="open_mousepad">Remote input</string>
+    <string name="open_textinput">Text input</string>
     <string name="mousepad_info">Move a finger on the screen to move the mouse cursor. Tap for a click, and use two/three fingers for right and middle buttons. Use 2 fingers to scroll. Use a long press to drag\'n drop.</string>
     <string name="mousepad_double_tap_settings_title">Set two finger tap action</string>
     <string name="mousepad_triple_tap_settings_title">Set three finger tap action</string>
@@ -160,6 +163,7 @@
     <string name="right_click">Send Right Click</string>
     <string name="middle_click">Send Middle Click</string>
     <string name="show_keyboard">Show Keyboard</string>
+    <string name="submit">Submit</string>
     <string name="device_not_paired">Device not paired</string>
     <string name="request_pairing">Request pairing</string>
     <string name="pairing_accept">Accept</string>
@@ -326,4 +330,5 @@
     <string name="notification_channel_receivenotification">Notifications from other devices</string>
 
     <string name="findmyphone_preference_key_ringtone" translatable="false">findmyphone_ringtone</string>
+    <string name="textinput_info">Enter text to send...</string>
 </resources>

--- a/src/org/kde/kdeconnect/Plugins/PluginFactory.java
+++ b/src/org/kde/kdeconnect/Plugins/PluginFactory.java
@@ -43,6 +43,7 @@ import org.kde.kdeconnect.Plugins.SharePlugin.SharePlugin;
 import org.kde.kdeconnect.Plugins.SystemvolumePlugin.SystemvolumePlugin;
 import org.kde.kdeconnect.Plugins.SMSPlugin.SMSPlugin;
 import org.kde.kdeconnect.Plugins.TelephonyPlugin.TelephonyPlugin;
+import org.kde.kdeconnect.Plugins.TextInputPlugin.TextInputPlugin;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -126,6 +127,7 @@ public class PluginFactory {
         PluginFactory.registerPlugin(SftpPlugin.class);
         PluginFactory.registerPlugin(NotificationsPlugin.class);
         PluginFactory.registerPlugin(ReceiveNotificationsPlugin.class);
+        PluginFactory.registerPlugin(TextInputPlugin.class);
         PluginFactory.registerPlugin(MousePadPlugin.class);
         PluginFactory.registerPlugin(PresenterPlugin.class);
         PluginFactory.registerPlugin(SharePlugin.class);

--- a/src/org/kde/kdeconnect/Plugins/TextInputPlugin/TextInputActivity.java
+++ b/src/org/kde/kdeconnect/Plugins/TextInputPlugin/TextInputActivity.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2019 Ondřej Hruška <ondra@ondrovo.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of
+ * the License or (at your option) version 3 or any later version
+ * accepted by the membership of KDE e.V. (or its successor approved
+ * by the membership of KDE e.V.), which shall act as a proxy
+ * defined in Section 14 of version 3 of the license.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.kde.kdeconnect.Plugins.TextInputPlugin;
+
+import android.os.Bundle;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
+import android.widget.TextView;
+
+import org.kde.kdeconnect.BackgroundService;
+import org.kde.kdeconnect.Device;
+import org.kde.kdeconnect.NetworkPacket;
+import org.kde.kdeconnect.UserInterface.ThemeUtil;
+import org.kde.kdeconnect_tp.R;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+public class TextInputActivity extends AppCompatActivity {
+    private String deviceId;
+
+    public void sendChars(CharSequence chars) {
+        final NetworkPacket np = new NetworkPacket(TextInputPlugin.PACKET_TYPE_TEXTINPUT_REQUEST);
+        np.set("key", chars.toString());
+        sendKeyPressPacket(np);
+    }
+
+    private void sendKeyPressPacket(final NetworkPacket np) {
+        BackgroundService.RunCommand(getBaseContext(), service -> {
+            Device device = service.getDevice(deviceId);
+            TextInputPlugin textInputPlugin = device.getPlugin(TextInputPlugin.class);
+            if (textInputPlugin == null) return;
+            textInputPlugin.sendKeyboardPacket(np);
+        });
+    }
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        ThemeUtil.setUserPreferredTheme(this);
+        setContentView(R.layout.activity_textinput);
+        deviceId = getIntent().getStringExtra("deviceId");
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        MenuInflater inflater = getMenuInflater();
+        inflater.inflate(R.menu.menu_textinput, menu);
+        return true;
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        switch (item.getItemId()) {
+            case R.id.menu_submit_text:
+                submitText();
+                return true;
+            default:
+                return super.onOptionsItemSelected(item);
+        }
+    }
+
+    private void submitText() {
+        TextView v = findViewById(R.id.textInputField);
+        CharSequence text = v.getText();
+        v.setText("");
+        sendChars(text);
+    }
+
+    @Override
+    protected void onStart() {
+        super.onStart();
+        BackgroundService.addGuiInUseCounter(this);
+    }
+
+    @Override
+    protected void onStop() {
+        super.onStop();
+        BackgroundService.removeGuiInUseCounter(this);
+    }
+}

--- a/src/org/kde/kdeconnect/Plugins/TextInputPlugin/TextInputPlugin.java
+++ b/src/org/kde/kdeconnect/Plugins/TextInputPlugin/TextInputPlugin.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2019 Ondřej Hruška <ondra@ondrovo.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of
+ * the License or (at your option) version 3 or any later version
+ * accepted by the membership of KDE e.V. (or its successor approved
+ * by the membership of KDE e.V.), which shall act as a proxy
+ * defined in Section 14 of version 3 of the license.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+*/
+
+package org.kde.kdeconnect.Plugins.TextInputPlugin;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.graphics.drawable.Drawable;
+
+import org.kde.kdeconnect.NetworkPacket;
+import org.kde.kdeconnect.Plugins.Plugin;
+import org.kde.kdeconnect_tp.R;
+
+import androidx.core.content.ContextCompat;
+
+public class TextInputPlugin extends Plugin {
+
+    // re-use the mousepad events, so we don't have to change the desktop software
+    public final static String PACKET_TYPE_TEXTINPUT_REQUEST = "kdeconnect.mousepad.request";
+
+    @Override
+    public String getDisplayName() {
+        return context.getString(R.string.pref_plugin_textinput);
+    }
+
+    @Override
+    public String getDescription() {
+        return context.getString(R.string.pref_plugin_textinput_desc);
+    }
+
+    @Override
+    public Drawable getIcon() {
+        return ContextCompat.getDrawable(context, R.drawable.ic_action_image_edit);
+    }
+
+    @Override
+    public boolean hasMainActivity() {
+        return true;
+    }
+
+    @Override
+    public void startMainActivity(Activity parentActivity) {
+        Intent intent = new Intent(parentActivity, TextInputActivity.class);
+        intent.putExtra("deviceId", device.getDeviceId());
+        parentActivity.startActivity(intent);
+    }
+
+    @Override
+    public String[] getSupportedPacketTypes() {
+        return new String[0];
+    }
+
+    @Override
+    public String[] getOutgoingPacketTypes() {
+        return new String[]{PACKET_TYPE_TEXTINPUT_REQUEST};
+    }
+
+    @Override
+    public String getActionName() {
+        return context.getString(R.string.open_textinput);
+    }
+
+    public void sendKeyboardPacket(NetworkPacket np) {
+        device.sendPacket(np);
+    }
+
+}


### PR DESCRIPTION
This plugin allows the user to use more complex input methods, such as
the Google's Handwriting Keyboard for Japanese. Text is composed in a
text field and submitted by a button in the top bar. Tested with English and Japanese.

Emoji don't work, but they don't work with the *MousePad* plugin either,
and I reused its event for sending text, so that bug is somewhere
deeper (maybe in the desktop software). Emoji are always sent as ??.

No changes in the desktop SW are needed for this to work.

<details>
  <summary>Click to see a screenshot</summary>  

  ![Picture](https://user-images.githubusercontent.com/2041118/52165057-dbee8700-26fb-11e9-80d0-a1fe943f841b.png)
</details>
