### PR TITLE
Find My Phone plugin API refresh

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -33,6 +33,7 @@
     <uses-permission android:name="android.permission.SEND_SMS" />
     <uses-permission android:name="android.permission.READ_SMS" />
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
 
     <application
         android:icon="@drawable/icon"

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 android {
     compileSdkVersion 28
     defaultConfig {
-        minSdkVersion 14
+        minSdkVersion 21
         targetSdkVersion 28
     }
     dexOptions {

--- a/src/org/kde/kdeconnect/Plugins/FindMyPhonePlugin/FindMyPhoneActivity.java
+++ b/src/org/kde/kdeconnect/Plugins/FindMyPhonePlugin/FindMyPhoneActivity.java
@@ -19,28 +19,47 @@
  */
 package org.kde.kdeconnect.Plugins.FindMyPhonePlugin;
 
+
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.media.AudioAttributes;
+import android.media.AudioFocusRequest;
 import android.media.AudioManager;
 import android.media.MediaPlayer;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
+import android.os.PowerManager;
 import android.preference.PreferenceManager;
 import android.provider.Settings;
 import android.util.Log;
 import android.view.Window;
 import android.view.WindowManager;
 
+import androidx.annotation.RequiresApi;
+
 import org.kde.kdeconnect.UserInterface.ThemeUtil;
 import org.kde.kdeconnect_tp.R;
 
-public class FindMyPhoneActivity extends Activity {
+import static android.os.Build.VERSION_CODES.O;
+
+
+public class FindMyPhoneActivity extends Activity implements MediaPlayer.OnPreparedListener,
+        AudioManager.OnAudioFocusChangeListener {
+
+    private final Object focusLock = new Object();
+    private int previousVolume = -1;
+    private AudioManager audioManager;
+
+    private AudioAttributes audioAttributes;
 
     private MediaPlayer mediaPlayer;
-    private int previousVolume;
-    private AudioManager audioManager;
+    private boolean playerPrepared = false;
+
+    private AudioFocusRequest focusRequest;
+    private boolean playbackDelayed;
 
     @Override
     protected void onNewIntent(Intent intent) {
@@ -48,6 +67,7 @@ public class FindMyPhoneActivity extends Activity {
 
         if (mediaPlayer != null) {
             // If this activity was already open and we received the ring packet again, just finish it
+            mediaPlayer.release();
             finish();
         }
         // otherwise the activity will become active again
@@ -61,6 +81,23 @@ public class FindMyPhoneActivity extends Activity {
 
         audioManager = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
 
+        // Prepare audio attributes for media requests
+        audioAttributes = new AudioAttributes.Builder()
+                .setUsage(AudioAttributes.USAGE_ALARM)
+                .setContentType(AudioAttributes.CONTENT_TYPE_UNKNOWN)
+                .setFlags(AudioAttributes.FLAG_AUDIBILITY_ENFORCED)
+                .build();
+
+        // Prepare request for temporary sole audio focus
+        if (Build.VERSION.SDK_INT >= O) {
+            focusRequest = new AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_EXCLUSIVE)
+                    .setAudioAttributes(audioAttributes)
+                    .setAcceptsDelayedFocusGain(true)
+                    .setWillPauseWhenDucked(true)
+                    .setOnAudioFocusChangeListener(this)
+                    .build();
+        }
+
         Window window = this.getWindow();
         window.addFlags(WindowManager.LayoutParams.FLAG_DISMISS_KEYGUARD |
                 WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED |
@@ -69,15 +106,12 @@ public class FindMyPhoneActivity extends Activity {
         findViewById(R.id.bFindMyPhone).setOnClickListener(view -> finish());
     }
 
+    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
     @Override
     protected void onStart() {
         super.onStart();
 
         try {
-            // Make sure we are heard even when the phone is silent, restore original volume later
-            previousVolume = audioManager.getStreamVolume(AudioManager.STREAM_ALARM);
-            audioManager.setStreamVolume(AudioManager.STREAM_ALARM, audioManager.getStreamMaxVolume(AudioManager.STREAM_ALARM), 0);
-
             SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
             Uri ringtone;
             String ringtoneString = prefs.getString(getString(R.string.findmyphone_preference_key_ringtone), "");
@@ -88,11 +122,17 @@ public class FindMyPhoneActivity extends Activity {
             }
 
             mediaPlayer = new MediaPlayer();
+            mediaPlayer.setAudioAttributes(audioAttributes);
+
+            // Prevent screen/CPU sleep during playback -- requries WAKE_LOCK permission!!
+            mediaPlayer.setWakeMode(getApplicationContext(), PowerManager.PARTIAL_WAKE_LOCK);
+
             mediaPlayer.setDataSource(this, ringtone);
-            mediaPlayer.setAudioStreamType(AudioManager.STREAM_ALARM);
             mediaPlayer.setLooping(true);
-            mediaPlayer.prepare();
-            mediaPlayer.start();
+
+            // Fire off async prepare, onPrepared() will pick up when ready
+            mediaPlayer.setOnPreparedListener(this);
+            mediaPlayer.prepareAsync();
 
         } catch (Exception e) {
             Log.e("FindMyPhoneActivity", "Exception", e);
@@ -100,14 +140,99 @@ public class FindMyPhoneActivity extends Activity {
 
     }
 
+    // implementation of the OnAudioFocusChangeListener
+
+    protected void playNow() {
+        if (mediaPlayer != null && playerPrepared) {
+            try {
+                // Make sure we are heard even when the phone is silent, restore original volume later
+                previousVolume = audioManager.getStreamVolume(AudioManager.STREAM_ALARM);
+                audioManager.setStreamVolume(AudioManager.STREAM_ALARM, audioManager.getStreamMaxVolume(AudioManager.STREAM_ALARM), 0);
+
+                // Finally start playback
+                mediaPlayer.start();
+
+            } catch (Exception e) {
+                Log.e("FindMyPhoneActivity", "Exception", e);
+            }
+        }
+    }
+
+    protected void endPlayback() {
+        try {
+            if (mediaPlayer != null) {
+                mediaPlayer.stop();
+                mediaPlayer.release();
+                mediaPlayer = null;
+            }
+            if (previousVolume >= 0) {
+                audioManager.setStreamVolume(AudioManager.STREAM_ALARM, previousVolume, 0);
+            }
+        } catch (Exception e) {
+            Log.e("FindMyPhoneActivity", "Exception", e);
+        }
+    }
+
     @Override
     protected void onStop() {
         super.onStop();
 
-        if (mediaPlayer != null) {
-            mediaPlayer.stop();
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+            int res = audioManager.abandonAudioFocusRequest(focusRequest);
         }
-        audioManager.setStreamVolume(AudioManager.STREAM_ALARM, previousVolume, 0);
+        synchronized (focusLock) {
+            playbackDelayed = false;
+        }
+        endPlayback();
     }
 
+    @Override
+    public void onAudioFocusChange(int focusChange) {
+        switch (focusChange) {
+            case AudioManager.AUDIOFOCUS_GAIN:
+                if (playbackDelayed) {
+                    synchronized (focusLock) {
+                        playbackDelayed = false;
+                    }
+                    playNow();
+                    break;
+                }
+                synchronized (focusLock) {
+                    playbackDelayed = false;
+                }
+                endPlayback();
+                break;
+            case AudioManager.AUDIOFOCUS_LOSS:
+            case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT:
+            case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK:
+                // If we lose focus once gained, stop playback
+                synchronized (focusLock) {
+                    playbackDelayed = false;
+                }
+                endPlayback();
+                break;
+        }
+    }
+
+    @Override
+    public void onPrepared(MediaPlayer mp) {
+        playerPrepared = true;
+
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+            // Attempt to gain sole audio focus (temporarily)
+            int res = audioManager.requestAudioFocus(focusRequest);
+            synchronized (focusLock) {
+                if (res == AudioManager.AUDIOFOCUS_REQUEST_FAILED) {
+                    playbackDelayed = false;
+                } else if (res == AudioManager.AUDIOFOCUS_REQUEST_GRANTED) {
+                    playbackDelayed = false;
+                    playNow();
+                } else if (res == AudioManager.AUDIOFOCUS_REQUEST_DELAYED) {
+                    playbackDelayed = true;
+                }
+            }
+        } else {
+            playNow();
+        }
+    }
 }


### PR DESCRIPTION
This is an update to the FindMyPhone plugin, attempting to make use of newer APIs to more correctly manage audio playback on newer Android releases. Highlights:

#### KDE Connect-wide
- Raise `minSdkVersion` from `14` to `21` (To access more recent APIs w/o lots of legacy fallback.)
- Add `WAKE_LOCK` to permissions requested in manifest file.
#### `FindMyPhoneActivity`
- Use `AudioAttributes` to replace deprecated `SetAudioStreamType()`
- Request & manage audio focus, on Android 26+
- Prevent screen / CPU sleep during playback (using `WAKE_LOCK`)
- Prepare `MediaPlayer` asynchronously, and `release()` when done

I'll be honest, I wrote this code working off of API docs and code samples, but I'm not supremely confident that it's all correct. It _compiles_ with no problems, and I built and installed it as an APK on my Android 6 phone, where it worked just the same as the version installed from Google Play. However, running on Android 6 means that most of the newer APIs (including Audio Focus) aren't accessed, and I don't have a newer device to test on. (Trying to run the app in an emulator failed, network-connectivity wise... I ended up with GSConnect trying to pair with _itself_.)

So, I'm submitting this in case it might be useful, but I would be surprised if it doesn't need at least some cleanup. It _certainly_ needs testing on newer devices, something I'm unable to do myself.