### PR TITLE
Use Google's R8 to shrink code and update versions of life-cycle dependencies 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,12 +55,12 @@ android {
     buildTypes {
         debug {
             minifyEnabled false
-            useProguard false
+            //useProguard false
             signingConfig signingConfigs.debug
         }
         release { //keep on 'release' for faster builds, set to 'all' when testing to make sure proguard is not deleting important stuff
             minifyEnabled true
-            useProguard true
+            //useProguard true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
@@ -82,9 +82,9 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.preference:preference:1.1.0'
     implementation 'androidx.recyclerview:recyclerview:1.0.0'
-    implementation 'androidx.lifecycle:lifecycle-runtime:2.1.0'
-    implementation "androidx.lifecycle:lifecycle-extensions:2.0.0"
-    implementation 'androidx.lifecycle:lifecycle-common-java8:2.1.0'
+    implementation 'androidx.lifecycle:lifecycle-runtime:2.2.0'
+    implementation "androidx.lifecycle:lifecycle-extensions:2.2.0"
+    implementation 'androidx.lifecycle:lifecycle-common-java8:2.2.0'
     implementation 'com.google.android.material:material:1.0.0'
     implementation 'com.jakewharton:disklrucache:2.0.2' //For caching album art bitmaps
     implementation 'com.jaredrummler:android-device-names:1.1.9' //To get a human-friendly device name

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 android.enableJetifier=true
 android.useAndroidX=true
+android.enableR8=true


### PR DESCRIPTION
- Use Google's R8 to shrink code instead of useProguard which is faster and more efficient.

- Update the lifecycle dependencies from versions 2.0.1 and 2.1.1 to the newer version 2.2.0