### PR TITLE
Accept data via Intent and pass them on to the host as keystrokes

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -255,6 +255,20 @@
                 android:value="org.kde.kdeconnect.UserInterface.MainActivity" />
         </activity>
         <activity
+            android:name="org.kde.kdeconnect.Plugins.MousePadPlugin.SendKeystrokesToHostActivity"
+            android:label="@string/pref_plugin_mousepad_send_keystrokes"
+            android:parentActivityName="org.kde.kdeconnect.UserInterface.MainActivity">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="org.kde.kdeconnect.UserInterface.MainActivity" />
+            <!-- Accept data with "text/keystrokes" to send the text to the connected host and emulate keystrokes -->
+            <intent-filter>
+                <action android:name="android.intent.action.SEND"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <data android:mimeType="text/keystrokes"/>
+            </intent-filter>
+        </activity>
+        <activity
             android:name="org.kde.kdeconnect.Plugins.PresenterPlugin.PresenterActivity"
             android:configChanges="orientation|keyboardHidden|screenSize"
             android:label="@string/pref_plugin_presenter"

--- a/res/drawable/ic_warning_red.xml
+++ b/res/drawable/ic_warning_red.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#7D2727"
+        android:pathData="M1,21h22L12,2 1,21zM13,18h-2v-2h2v2zM13,14h-2v-4h2v4z"/>
+</vector>

--- a/res/layout/activity_sendkeystrokes.xml
+++ b/res/layout/activity_sendkeystrokes.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+
+    android:id="@+id/sendkeystrokes_view"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:keepScreenOn="true"
+    android:orientation="vertical"
+    android:padding="4dp">
+
+    <com.google.android.material.textfield.TextInputLayout
+        style="@style/Widget.MaterialComponents.TextInputLayout.FilledBox"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingTop="5dp"
+        app:errorEnabled="true">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/textToSend"
+            style="@style/Widget.MaterialComponents.TextInputEditText.FilledBox"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:cursorVisible="true"
+            android:hint="@string/sendkeystrokes_textbox_hint"
+            android:inputType="text"
+            android:lines="1"
+            android:maxLines="1"
+            android:scrollHorizontally="true"
+            android:text="" />
+
+    </com.google.android.material.textfield.TextInputLayout>
+
+
+    <com.google.android.material.switchmaterial.SwitchMaterial
+        android:id="@+id/switch_always_trust_sender"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:switchPadding="4dp"
+        android:text="@string/sendkeystrokes_always_trust" />
+
+
+    <TextView
+        android:id="@+id/always_trust_warning"
+        android:visibility="gone"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:drawableStart="@drawable/ic_warning_red"
+        android:drawableLeft="@drawable/ic_warning_red"
+        android:text="@string/sendkeystrokes_always_trust_warning" />
+
+    <ListView
+        android:id="@+id/devices_list"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:addStatesFromChildren="true"
+        android:divider="@null"
+        android:dividerHeight="0dp"
+        android:orientation="vertical"
+        android:paddingTop="16dip"
+        tools:context=".MainActivity" />
+
+
+</LinearLayout>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -110,7 +110,30 @@
         <item>strong</item>
         <item>stronger</item>
     </string-array>
-    <string name="category_connected_devices">Connected devices</string>
+
+  <string name="pref_plugin_mousepad_send_keystrokes">Send as keystrokes</string>
+  <string name="sendkeystrokes_send_to">Send keystrokes to</string>
+  <string name="sendkeystrokes_textbox_hint">Send keystrokes to host</string>
+  <string name="sendkeystrokes_disabled_toast">Sending keystrokes is disabled - enable it in the settings</string>
+  <string name="sendkeystrokes_wrong_data"><![CDATA[Invalid mime type - needs to be \'text/keystrokes\']]></string>
+  <string name="sendkeystrokes_sent_text">Sent %1s to device %2s</string>
+  <string name="sendkeystrokes_always_trust"><![CDATA[Always trust \'<b>%1s</b>\' and send without confirmation]]></string>
+  <string name="sendkeystrokes_always_trust_warning">Warning: be sure this app can not send any untrusted text which could trigger harmful actions on the host device</string>
+
+  <string name="sendkeystrokes_pref_category_summary">This module allows other apps to share text segments as keystrokes which will get send to the connected host</string>
+  <string name="sendkeystrokes_pref_category_title">Send Keystrokes</string>
+  <string name="sendkeystrokes_pref_enabled">Enable Keystrokes sending</string>
+  <string name="sendkeystrokes_pref_enabled_summary"><![CDATA[Listen for data with mime type \'text/keystrokes\']]></string>
+  <string name="sendkeystrokes_pref_category_trusted_apps_title">Trusted apps</string>
+  <string name="sendkeystrokes_pref_category_trusted_apps_summary">These apps are able to send without confirmation</string>
+
+  <string name="sendkeystrokes_pref_trusted_apps" translatable="false">send_keystrokes_trusted_apps</string>
+  <string name="sendkeystrokes_pref_category" translatable="false">category_send_keystrokes</string>
+  <string name="sendkeystrokes_pref_category_trusted_apps" translatable="false">category_trusted_apps</string>
+
+  <string name="pref_sendkeystrokes_enabled" translatable="false">pref_sendkeystrokes_enabled</string>
+
+  <string name="category_connected_devices">Connected devices</string>
     <string name="category_not_paired_devices">Available devices</string>
     <string name="category_remembered_devices">Remembered devices</string>
     <string name="device_menu_plugins">Plugin settings</string>
@@ -402,7 +425,7 @@
     </string-array>
 
     <string name="theme_dialog_title">Choose theme</string>
-    <string-array name="theme_list">
+  <string-array name="theme_list">
       <item>Set by Battery Saver</item>
       <item>Light</item>
       <item>Dark</item>

--- a/res/xml/mousepadplugin_preferences.xml
+++ b/res/xml/mousepadplugin_preferences.xml
@@ -46,4 +46,26 @@
         android:defaultValue="false"
         android:key="@string/mousepad_scroll_direction"
         android:title="@string/mousepad_scroll_direction_title" />
+
+
+    <org.kde.kdeconnect.Helpers.LongSummaryPreferenceCategory
+        android:key="@string/sendkeystrokes_pref_category"
+        android:summary="@string/sendkeystrokes_pref_category_summary"
+        android:title="@string/sendkeystrokes_pref_category_title">
+
+        <CheckBoxPreference
+            android:id="@+id/pref_keystrokes_enable"
+            android:defaultValue="true"
+            android:key="@string/pref_sendkeystrokes_enabled"
+            android:title="@string/sendkeystrokes_pref_enabled"
+            android:summary="@string/sendkeystrokes_pref_enabled_summary"
+            />
+
+    </org.kde.kdeconnect.Helpers.LongSummaryPreferenceCategory>
+    <PreferenceCategory
+        android:key="@string/sendkeystrokes_pref_category_trusted_apps"
+        android:summary="@string/sendkeystrokes_pref_category_trusted_apps_summary"
+        android:title="@string/sendkeystrokes_pref_category_trusted_apps_title">
+
+    </PreferenceCategory>
 </PreferenceScreen>

--- a/src/org/kde/kdeconnect/Helpers/LongSummaryPreferenceCategory.java
+++ b/src/org/kde/kdeconnect/Helpers/LongSummaryPreferenceCategory.java
@@ -1,0 +1,29 @@
+package org.kde.kdeconnect.Helpers;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.View;
+import android.widget.TextView;
+
+import androidx.preference.PreferenceCategory;
+import androidx.preference.PreferenceViewHolder;
+
+// the default Preference Category only shows a one-line summary
+public class LongSummaryPreferenceCategory extends PreferenceCategory {
+    public LongSummaryPreferenceCategory(Context ctx, AttributeSet attrs, int defStyle) {
+        super(ctx, attrs, defStyle);
+    }
+
+    public LongSummaryPreferenceCategory(Context ctx, AttributeSet attrs) {
+        super(ctx, attrs);
+    }
+
+    @Override
+    public void onBindViewHolder(PreferenceViewHolder holder) {
+        super.onBindViewHolder(holder);
+        TextView summary = (TextView) holder.findViewById(android.R.id.summary);
+        summary.setMaxLines(3);
+        summary.setSingleLine(false);
+    }
+
+}

--- a/src/org/kde/kdeconnect/Plugins/MousePadPlugin/MousePadPlugin.java
+++ b/src/org/kde/kdeconnect/Plugins/MousePadPlugin/MousePadPlugin.java
@@ -8,15 +8,22 @@ package org.kde.kdeconnect.Plugins.MousePadPlugin;
 
 import android.app.Activity;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.graphics.drawable.Drawable;
 
 import org.kde.kdeconnect.Device;
 import org.kde.kdeconnect.NetworkPacket;
 import org.kde.kdeconnect.Plugins.Plugin;
 import org.kde.kdeconnect.Plugins.PluginFactory;
+import org.kde.kdeconnect.Plugins.SftpPlugin.SftpSettingsFragment;
+import org.kde.kdeconnect.UserInterface.PluginSettingsFragment;
 import org.kde.kdeconnect_tp.R;
 
 import androidx.core.content.ContextCompat;
+import androidx.preference.SwitchPreference;
+
+import java.util.Collections;
+import java.util.Set;
 
 @PluginFactory.LoadablePlugin
 public class MousePadPlugin extends Plugin {
@@ -53,6 +60,11 @@ public class MousePadPlugin extends Plugin {
     @Override
     public boolean hasSettings() {
         return true;
+    }
+
+    @Override
+    public PluginSettingsFragment getSettingsFragment(Activity activity) {
+        return MousePadSettingsFragment.newInstance(getPluginKey());
     }
 
     @Override

--- a/src/org/kde/kdeconnect/Plugins/MousePadPlugin/MousePadSettingsFragment.java
+++ b/src/org/kde/kdeconnect/Plugins/MousePadPlugin/MousePadSettingsFragment.java
@@ -1,0 +1,79 @@
+package org.kde.kdeconnect.Plugins.MousePadPlugin;
+
+import android.content.SharedPreferences;
+import android.os.Bundle;
+
+import androidx.annotation.NonNull;
+import androidx.preference.PreferenceCategory;
+import androidx.preference.PreferenceScreen;
+import androidx.preference.SwitchPreference;
+
+import org.apache.commons.lang3.StringUtils;
+import org.kde.kdeconnect.UserInterface.PluginSettingsFragment;
+import org.kde.kdeconnect_tp.R;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+public class MousePadSettingsFragment extends PluginSettingsFragment {
+
+    public static MousePadSettingsFragment newInstance(@NonNull String pluginKey) {
+        MousePadSettingsFragment fragment = new MousePadSettingsFragment();
+        fragment.setArguments(pluginKey);
+        return fragment;
+    }
+
+    public MousePadSettingsFragment() {
+    }
+
+
+    @Override
+    public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
+        super.onCreatePreferences(savedInstanceState, rootKey);
+
+        PreferenceScreen preferenceScreen = getPreferenceScreen();
+        PreferenceCategory categoryTrustedApps = preferenceScreen
+                .findPreference(getString(R.string.sendkeystrokes_pref_category_trusted_apps));
+
+        SharedPreferences prefs = getPreferenceManager().getSharedPreferences();
+        String prefsTrustedAppsKey = getString(R.string.sendkeystrokes_pref_trusted_apps);
+        Set<String> trustedApps = prefs.getStringSet(prefsTrustedAppsKey, Collections.emptySet());
+
+        if (trustedApps.size() == 0) {
+            categoryTrustedApps.setVisible(false);
+        } else {
+            for (String trustedApp : trustedApps) {
+                SwitchPreference switchPreference = new SwitchPreference(getPreferenceManager().getContext());
+                String appName = StringUtils.substringAfterLast(trustedApp, ".");
+                switchPreference.setTitle(appName);
+                switchPreference.setSummary(trustedApp);
+                switchPreference.setKey(trustedApp);
+                switchPreference.setPersistent(false); // we save it on our own
+                switchPreference.setChecked(true);  // if its in the list, its true; if the user sets it to false, it will disappear from the list on next setting
+                categoryTrustedApps.addPreference(switchPreference);
+
+
+                // all the trusted apps are stored in one StringSet Preference -> combine all checked
+                // apps and store it in the setting when one is changed
+                switchPreference.setOnPreferenceChangeListener((preference, newValue) -> {
+                    HashSet<String> save = new HashSet<>(trustedApps.size());
+                    for (String key : trustedApps) {
+                        SwitchPreference pref = preferenceScreen.findPreference(key);
+
+                        // this event is called before the preference has its new value - use the event based value for the affected one
+                        // but use the preference for the other ones
+                        boolean checked = key.equals(preference.getKey()) ? (boolean) newValue : pref.isChecked();
+                        if (checked) {
+                            save.add(key);
+                        }
+                    }
+                    prefs.edit().putStringSet(prefsTrustedAppsKey, save).apply();
+                    return true;
+                });
+            }
+        }
+    }
+
+
+}

--- a/src/org/kde/kdeconnect/Plugins/MousePadPlugin/SendKeystrokesToHostActivity.java
+++ b/src/org/kde/kdeconnect/Plugins/MousePadPlugin/SendKeystrokesToHostActivity.java
@@ -1,0 +1,153 @@
+package org.kde.kdeconnect.Plugins.MousePadPlugin;
+
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.os.Build;
+import android.os.Bundle;
+import android.preference.PreferenceManager;
+import android.text.Html;
+import android.view.View;
+import android.widget.Toast;
+
+import androidx.annotation.RequiresApi;
+import androidx.appcompat.app.AppCompatActivity;
+
+import org.kde.kdeconnect.BackgroundService;
+import org.kde.kdeconnect.Device;
+import org.kde.kdeconnect.NetworkPacket;
+import org.kde.kdeconnect.UserInterface.List.EntryItem;
+import org.kde.kdeconnect.UserInterface.List.ListAdapter;
+import org.kde.kdeconnect.UserInterface.List.SectionItem;
+import org.kde.kdeconnect.UserInterface.ThemeUtil;
+import org.kde.kdeconnect_tp.R;
+import org.kde.kdeconnect_tp.databinding.ActivitySendkeystrokesBinding;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+public class SendKeystrokesToHostActivity extends AppCompatActivity {
+    private ActivitySendkeystrokesBinding binding;
+    private boolean sendingAppIsTrusted;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        ThemeUtil.setUserPreferredTheme(this);
+
+        binding = ActivitySendkeystrokesBinding.inflate(getLayoutInflater());
+        setContentView(binding.getRoot());
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP_MR1) // needed for this.getReferrer()
+    @Override
+    protected void onStart() {
+        super.onStart();
+
+
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
+        if (!prefs.getBoolean(getString(R.string.pref_sendkeystrokes_enabled), true)){
+            Toast.makeText(getApplicationContext(), R.string.sendkeystrokes_disabled_toast,Toast.LENGTH_LONG).show();
+            finish();
+        } else {
+
+            final Intent intent = getIntent();
+            String type = intent.getType();
+            if ("text/keystrokes".equals(type)) {
+                String callingActivity = this.getReferrer().getHost();
+                String toSend = intent.getStringExtra(Intent.EXTRA_TEXT);
+                binding.textToSend.setText(toSend);
+                binding.switchAlwaysTrustSender.setText(Html.fromHtml( // format as HTML to allow a part of the text to be bold
+                        getResources().getString(R.string.sendkeystrokes_always_trust, Html.escapeHtml(callingActivity))
+                        )
+                );
+
+                // subscribe to new connected devices
+                BackgroundService.RunCommand(this, service -> {
+                    service.onNetworkChange();
+                    service.addDeviceListChangedCallback("SendKeystrokesToHostActivity", this::updateComputerList);
+                });
+
+                // list all currently connected devices
+                updateComputerList();
+
+
+                // set the "trusted app" switch, which allows sending keystrokes without confirmation
+                // not sure, why this is coming from strings.xml - just keeping it with the existing code style
+                String prefsTrustedAppsKey = getString(R.string.sendkeystrokes_pref_trusted_apps);
+                binding.switchAlwaysTrustSender.setOnCheckedChangeListener((elem, isSet) -> {
+                    // make a mutable copy of the set from the preferences
+                    Set<String> trustedApps = new HashSet<>(prefs.getStringSet(prefsTrustedAppsKey, Collections.emptySet()));
+
+                    if (isSet) {
+                        trustedApps.add(callingActivity);
+                    } else {
+                        trustedApps.remove(callingActivity);
+                    }
+                    prefs.edit().putStringSet(prefsTrustedAppsKey, trustedApps).apply();
+                    binding.alwaysTrustWarning.setVisibility(isSet ? View.VISIBLE : View.GONE);
+                });
+
+                sendingAppIsTrusted = prefs.getStringSet(prefsTrustedAppsKey, Collections.emptySet()).contains(callingActivity);
+                binding.switchAlwaysTrustSender.setChecked(sendingAppIsTrusted);
+            } else {
+                Toast.makeText(getApplicationContext(), R.string.sendkeystrokes_wrong_data,Toast.LENGTH_LONG).show();
+                finish();
+            }
+        }
+    }
+
+    private void sendKeys(Device deviceId) {
+        String toSend;
+        if (binding.textToSend.getText() != null && (toSend = binding.textToSend.getText().toString().trim()).length() > 0) {
+            final NetworkPacket np = new NetworkPacket(MousePadPlugin.PACKET_TYPE_MOUSEPAD_REQUEST);
+            np.set("key", toSend);
+            BackgroundService.RunWithPlugin(this, deviceId.getDeviceId(), MousePadPlugin.class, plugin -> plugin.sendKeyboardPacket(np));
+            Toast.makeText(
+                    getApplicationContext(),
+                    getString(R.string.sendkeystrokes_sent_text,toSend, deviceId.getName()),
+                    Toast.LENGTH_SHORT
+            ).show();
+
+        }
+    }
+
+
+    private void updateComputerList() {
+        BackgroundService.RunCommand(this, service -> {
+
+            Collection<Device> devices = service.getDevices().values();
+            final ArrayList<Device> devicesList = new ArrayList<>();
+            final ArrayList<ListAdapter.Item> items = new ArrayList<>();
+
+            SectionItem section = new SectionItem(getString(R.string.sendkeystrokes_send_to));
+            items.add(section);
+
+            for (Device d : devices) {
+                if (d.isReachable() && d.isPaired()) {
+                    devicesList.add(d);
+                    items.add(new EntryItem(d.getName()));
+                    section.isEmpty = false;
+                }
+            }
+            runOnUiThread(() -> {
+                binding.devicesList.setAdapter(new ListAdapter(SendKeystrokesToHostActivity.this, items));
+                binding.devicesList.setOnItemClickListener((adapterView, view, i, l) -> {
+                    Device device = devicesList.get(i - 1); // NOTE: -1 because of the title!
+                    sendKeys(device);
+                    this.finish(); // close the activity
+                });
+            });
+
+            // only one device is connected and we trust the sending app identifier -> send it and close the activity
+            if (devicesList.size() == 1 && sendingAppIsTrusted) {
+                Device device = devicesList.get(0);
+                sendKeys(device);
+                this.finish(); // close the activity
+            }
+        });
+    }
+}
+


### PR DESCRIPTION
Adds new functionality to the MousepadPlugin to accept data via Intent and pass them on to the host as keystrokes via the existing MousePadPlugin.PACKET_TYPE_MOUSEPAD_REQUEST PackageType

This allows other apps to send a Intent:
```
        Intent sendIntent = new Intent(Intent.ACTION_SEND);
        sendIntent.setType("text/keystrokes");
        sendIntent.putExtra(Intent.EXTRA_TEXT, textToSend);
        if (sendIntent.resolveActivity(this.context.getPackageManager()) != null) {
            this.context.startActivity(sendIntent);
        }
```

which then shows a confirm dialog and allows to pass the text as keystrokes to the host.
The confirm dialog also has the option to white-list a sending application (by its package name) and allow it to send without confirmation.

This could be used by other apps like password managers or OTP Tools to easily send the code to the desktop.

See here for a screen recording on how it works: https://imgur.com/a/uwjbESq / https://imgur.com/a/cBm5yOi
