### PR TITLE
Add option to cache URLs shared to unreachable devices

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -262,6 +262,7 @@ SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only OR LicenseRef-KDE-Accepted
     <string name="mpris_notification_settings_summary">Allow controlling your media players without opening KDE Connect</string>
     <string name="mpris_notification_key" translatable="false">mpris_notification_enabled</string>
     <string name="share_to">Share To…</string>
+    <string name="unreachable_device">(Unreachable)</string>
     <string name="protocol_version_newer">This device uses a newer protocol version</string>
     <string name="plugin_settings_with_name">%s settings</string>
     <string name="invalid_device_name">Invalid device name</string>


### PR DESCRIPTION
This change allows for caching the HTTP/HTTPS URLs shared to paired but unreachable devices. Once those devices become reachable, the URLs are delivered to them.