### PR TITLE
[Feature] Added volume keys feature in PresenterPlugin

### DIFF
--- a/res/values-it/strings.xml
+++ b/res/values-it/strings.xml
@@ -432,4 +432,5 @@
   <string name="ping_in_progress">Ping in corso…</string>
   <string name="device_host_invalid">L\'host non è valido. Utilizza un nome host valido, IPv4 o IPv6</string>
   <string name="device_host_duplicate">L\'host esiste già nell\'elenco</string>
+    <string name="presenter_volume_keys">Abilita tasti volume</string>
 </resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -595,5 +595,6 @@ SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only OR LicenseRef-KDE-Accepted
 
     <string name="device_host_invalid">Host is invalid. Use a valid hostname, IPv4, or IPv6</string>
     <string name="device_host_duplicate">Host already exists in the list</string>
+  <string name="presenter_volume_keys">Enable volume keys</string>
 
 </resources>

--- a/src/org/kde/kdeconnect/Plugins/PresenterPlugin/PresenterPlugin.java
+++ b/src/org/kde/kdeconnect/Plugins/PresenterPlugin/PresenterPlugin.java
@@ -9,11 +9,12 @@ package org.kde.kdeconnect.Plugins.PresenterPlugin;
 
 import static org.kde.kdeconnect.Plugins.MousePadPlugin.KeyListenerView.SpecialKeysMap;
 
+import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.view.KeyEvent;
-
+import android.content.SharedPreferences;
 import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
 
@@ -29,6 +30,15 @@ public class PresenterPlugin extends Plugin {
 
     private final static String PACKET_TYPE_PRESENTER = "kdeconnect.presenter";
     private final static String PACKET_TYPE_MOUSEPAD_REQUEST = "kdeconnect.mousepad.request";
+    private SharedPreferences sharedPreferences;
+    private boolean volumeKeysEnabled;
+
+    @Override
+    public boolean onCreate(){
+        sharedPreferences = context.getSharedPreferences(getSharedPreferencesName(),Context.MODE_PRIVATE);
+        volumeKeysEnabled = sharedPreferences.getBoolean("volumeKeys", false);
+        return true;
+    }
 
     public boolean isPointerSupported() {
         return getDevice().supportsPacketType(PACKET_TYPE_PRESENTER);
@@ -119,5 +129,16 @@ public class PresenterPlugin extends Plugin {
         NetworkPacket np = new NetworkPacket(PACKET_TYPE_PRESENTER);
         np.set("stop", true);
         getDevice().sendPacket(np);
+    }
+
+    public boolean isVolumeKeysEnabled() {
+        return volumeKeysEnabled;
+    }
+
+    @SuppressLint("CommitPrefEdits")
+    public void setVolumeKeysEnabled(boolean volumeKeysEnabled) {
+        this.volumeKeysEnabled = volumeKeysEnabled;
+        sharedPreferences.edit().putBoolean("volumeKeys", volumeKeysEnabled);
+
     }
 }


### PR DESCRIPTION
**Added the feature to change slides in PresenterPlugin with volume keys.**

I find it an important feature to have (i noticed that it's supported only for API < 33 and on locked screen, but i find it useful to have even with unlocked screen).

**Infos:**

- The option is set false by default, but the user can enable it using option in appBar, entering the PresenterPlugin view.
- The preference is saved in sharedPreferences under "volumeKeys" value, so the option stays after app is terminated.
- The check  "action == KeyEvent.ACTION_UP" is to prevent the button to skips slides if the user keeps the button hold.

I've translated the string in italian (other than english ofc), should be translated in other languages.

I've tested with my own device before requesting.

Be free to tell me changes to make if something is wrong or could be improved. 