### PR TITLE
Accept loopback paths for explicit tailnet peers

### DIFF
--- a/src/main/java/org/kde/kdeconnect/backends/lan/LanLinkProvider.java
+++ b/src/main/java/org/kde/kdeconnect/backends/lan/LanLinkProvider.java
@@ -135,8 +135,13 @@ public class LanLinkProvider extends BaseLinkProvider {
 
         InetAddress address = socket.getInetAddress();
 
+        boolean privateAddress = isPrivateAddress(address);
         boolean explicitPeer = isConfiguredCustomDevice(address);
-        if (!isPrivateAddress(address) && !explicitPeer) {
+        boolean loopbackProxyPeer = isLoopbackCustomDeviceProxy(address);
+        if (loopbackProxyPeer) {
+            Log.i("LanLinkProvider", "Accepting loopback TCP packet as a custom-device proxy path");
+        }
+        if (!privateAddress && !explicitPeer && !loopbackProxyPeer) {
             Log.i("LanLinkProvider", "Discarding TCP packet from a non-local IP " + address);
             return;
         }
@@ -158,7 +163,7 @@ public class LanLinkProvider extends BaseLinkProvider {
             return;
         }
 
-        final Pair<NetworkPacket, Boolean> pair = unserializeReceivedIdentityPacket(message, explicitPeer);
+        final Pair<NetworkPacket, Boolean> pair = unserializeReceivedIdentityPacket(message, explicitPeer || loopbackProxyPeer);
         if (pair == null) {
             return;
         }
@@ -261,6 +266,10 @@ public class LanLinkProvider extends BaseLinkProvider {
         return CustomDevicesActivity.getCustomDeviceList(context).stream()
                 .map(DeviceHost::toString)
                 .anyMatch(host -> resolvesToAddress(host, address));
+    }
+
+    private boolean isLoopbackCustomDeviceProxy(InetAddress address) {
+        return address.isLoopbackAddress() && !CustomDevicesActivity.getCustomDeviceList(context).isEmpty();
     }
 
     private boolean resolvesToAddress(String host, InetAddress expectedAddress) {

--- a/src/main/java/org/kde/kdeconnect/backends/lan/LanLinkProvider.java
+++ b/src/main/java/org/kde/kdeconnect/backends/lan/LanLinkProvider.java
@@ -94,7 +94,7 @@ public class LanLinkProvider extends BaseLinkProvider {
         super.onConnectionLost(link);
     }
 
-    Pair<NetworkPacket, Boolean> unserializeReceivedIdentityPacket(String message) {
+    Pair<NetworkPacket, Boolean> unserializeReceivedIdentityPacket(String message, boolean explicitPeer) {
         NetworkPacket identityPacket;
         try {
             identityPacket = NetworkPacket.unserialize(message);
@@ -121,8 +121,8 @@ public class LanLinkProvider extends BaseLinkProvider {
         }
 
         boolean deviceTrusted = TrustedDevices.isTrustedDevice(context, deviceId);
-        if (!deviceTrusted && !TrustedNetworkHelper.isTrustedNetwork(context)) {
-            Log.i("KDE/LanLinkProvider", "Ignoring identity packet because the device is not trusted and I'm not on a trusted network.");
+        if (!deviceTrusted && !TrustedNetworkHelper.isTrustedNetwork(context) && !explicitPeer) {
+            Log.i("KDE/LanLinkProvider", "Ignoring identity packet because the device is not trusted, I'm not on a trusted network, and it is not an explicit peer.");
             return null;
         }
 
@@ -135,8 +135,9 @@ public class LanLinkProvider extends BaseLinkProvider {
 
         InetAddress address = socket.getInetAddress();
 
-        if (!isPrivateAddress(address)) {
-            Log.i("LanLinkProvider", "Discarding TCP packet from a non-local IP");
+        boolean explicitPeer = isConfiguredCustomDevice(address);
+        if (!isPrivateAddress(address) && !explicitPeer) {
+            Log.i("LanLinkProvider", "Discarding TCP packet from a non-local IP " + address);
             return;
         }
 
@@ -157,7 +158,7 @@ public class LanLinkProvider extends BaseLinkProvider {
             return;
         }
 
-        final Pair<NetworkPacket, Boolean> pair = unserializeReceivedIdentityPacket(message);
+        final Pair<NetworkPacket, Boolean> pair = unserializeReceivedIdentityPacket(message, explicitPeer);
         if (pair == null) {
             return;
         }
@@ -212,8 +213,9 @@ public class LanLinkProvider extends BaseLinkProvider {
 
         final InetAddress address = packet.getAddress();
 
-        if (!isPrivateAddress(address)) {
-            Log.i("LanLinkProvider", "Discarding UDP packet from a non-local IP");
+        boolean explicitPeer = isConfiguredCustomDevice(address);
+        if (!isPrivateAddress(address) && !explicitPeer) {
+            Log.i("LanLinkProvider", "Discarding UDP packet from a non-local IP " + address);
             return;
         }
 
@@ -222,9 +224,9 @@ public class LanLinkProvider extends BaseLinkProvider {
             return;
         }
 
-        String message = new String(packet.getData(), Charsets.UTF_8);
+        String message = new String(packet.getData(), packet.getOffset(), packet.getLength(), Charsets.UTF_8);
 
-        final Pair<NetworkPacket, Boolean> pair = unserializeReceivedIdentityPacket(message);
+        final Pair<NetworkPacket, Boolean> pair = unserializeReceivedIdentityPacket(message, explicitPeer);
         if (pair == null) {
             return;
         }
@@ -252,6 +254,26 @@ public class LanLinkProvider extends BaseLinkProvider {
         out.flush();
 
         identityPacketReceived(identityPacket, socket, LanLink.ConnectionStarted.Remotely, deviceTrusted);
+    }
+
+
+    private boolean isConfiguredCustomDevice(InetAddress address) {
+        return CustomDevicesActivity.getCustomDeviceList(context).stream()
+                .map(DeviceHost::toString)
+                .anyMatch(host -> resolvesToAddress(host, address));
+    }
+
+    private boolean resolvesToAddress(String host, InetAddress expectedAddress) {
+        try {
+            for (InetAddress address : InetAddress.getAllByName(host)) {
+                if (address.equals(expectedAddress)) {
+                    return true;
+                }
+            }
+        } catch (UnknownHostException e) {
+            Log.w("LanLinkProvider", "Failed to resolve custom device " + host, e);
+        }
+        return false;
     }
 
     private void configureSocket(Socket socket) {

--- a/src/main/java/org/kde/kdeconnect/backends/lan/LanLinkProvider.java
+++ b/src/main/java/org/kde/kdeconnect/backends/lan/LanLinkProvider.java
@@ -115,14 +115,14 @@ public class LanLinkProvider extends BaseLinkProvider {
             return null;
         }
 
-        if (rateLimitByDeviceId(deviceId)) {
-            Log.i("LanLinkProvider", "Discarding second packet from the same device " + deviceId + " received too quickly");
-            return null;
-        }
-
         boolean deviceTrusted = TrustedDevices.isTrustedDevice(context, deviceId);
         if (!deviceTrusted && !TrustedNetworkHelper.isTrustedNetwork(context) && !explicitPeer) {
             Log.i("KDE/LanLinkProvider", "Ignoring identity packet because the device is not trusted, I'm not on a trusted network, and it is not an explicit peer.");
+            return null;
+        }
+
+        if (rateLimitByDeviceId(deviceId)) {
+            Log.i("LanLinkProvider", "Discarding second accepted packet from the same device " + deviceId + " received too quickly");
             return null;
         }
 

--- a/src/main/java/org/kde/kdeconnect/ui/CustomDevicesActivity.java
+++ b/src/main/java/org/kde/kdeconnect/ui/CustomDevicesActivity.java
@@ -26,6 +26,7 @@ import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import com.google.android.material.snackbar.BaseTransientBottomBar;
 import com.google.android.material.snackbar.Snackbar;
 
+import org.kde.kdeconnect.BackgroundService;
 import org.kde.kdeconnect.DeviceHost;
 import org.kde.kdeconnect.helpers.WindowHelper;
 import org.kde.kdeconnect.base.BaseActivity;
@@ -184,6 +185,7 @@ public class CustomDevicesActivity extends BaseActivity<ActivityCustomDevicesBin
         customDeviceList.remove(lastDeletedCustomDevice.position);
         customDevicesAdapter.notifyItemRemoved(lastDeletedCustomDevice.position);
         saveList();
+        BackgroundService.ForceRefreshConnections(this);
         showEmptyListMessageIfRequired();
 
         Snackbar.make(recyclerView, R.string.custom_device_deleted, Snackbar.LENGTH_LONG)
@@ -192,6 +194,7 @@ public class CustomDevicesActivity extends BaseActivity<ActivityCustomDevicesBin
                     customDevicesAdapter.notifyItemInserted(lastDeletedCustomDevice.position);
                     lastDeletedCustomDevice = null;
                     saveList();
+                    BackgroundService.ForceRefreshConnections(CustomDevicesActivity.this);
                     showEmptyListMessageIfRequired();
                 })
                 .addCallback(new BaseTransientBottomBar.BaseCallback<>() {
@@ -247,6 +250,7 @@ public class CustomDevicesActivity extends BaseActivity<ActivityCustomDevicesBin
                         }
 
                         saveList();
+                        BackgroundService.ForceRefreshConnections(CustomDevicesActivity.this);
                         showEmptyListMessageIfRequired();
                     }
                     else {


### PR DESCRIPTION
## Summary

Some Android userspace VPN/tailnet/proxy implementations can deliver inbound peer TCP to KDE Connect Android as a loopback socket. When that happens, a peer configured through **Add devices by IP** can be rejected before KDE Connect reads the identity packet, because the app-visible source is `127.0.0.1` rather than the configured `100.64.x.x` address.

This preserves the existing safety boundary by accepting loopback as a custom-device proxy path only when the user has configured custom devices. KDE Connect still performs its normal identity and TLS handling after this initial address gate.

## Related bug

https://bugs.kde.org/show_bug.cgi?id=520110

This is related to, but distinct from, the fixed CGNAT/ULA filtering regression in Bug 515707 / MR 625.

## Validation

- `./gradlew compileDebugJavaWithJavac`
- Locally validated in a fork before trimming diagnostic logs: Android phone reachable over a sing-box tailnet, desktop packets reached phone port 1716, app-visible socket appeared as loopback, and pairing succeeded after allowing the loopback custom-device proxy path.
